### PR TITLE
fix: update CI/CD workflow Docker tagging and job dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -226,7 +226,6 @@ jobs:
         with:
           images: ${{ steps.docker_config.outputs.image_name }}
           tags: |
-            type=ref,event=branch
             type=raw,value=${{ steps.docker_config.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -246,8 +245,8 @@ jobs:
   push-docker:
     name: Push to Docker Hub
     runs-on: ubuntu-latest
-    needs: build-jar
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && vars.DOCKER_USERNAME != '' && needs.build-jar.result == 'success'
+    needs: build-docker
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && vars.DOCKER_USERNAME != '' && needs.build-docker.result == 'success'
 
     steps:
       - name: Checkout code
@@ -281,7 +280,6 @@ jobs:
         with:
           images: ${{ vars.DOCKER_USERNAME }}/${{ env.DOCKER_IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rabbitmq</groupId>
         <artifactId>rabbitmq-admin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>rabbitmq-admin-backend</artifactId>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-admin-frontend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rabbitmq</groupId>
         <artifactId>rabbitmq-admin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>rabbitmq-admin-frontend</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rabbitmq</groupId>
     <artifactId>rabbitmq-admin</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>pom</packaging>
 
     <name>RabbitMQ Admin</name>

--- a/radmin-cli
+++ b/radmin-cli
@@ -15,7 +15,7 @@ NC='\033[0m' # No Color
 
 # Project info
 PROJECT_NAME="RabbitMQ Admin"
-VERSION="0.1.1"
+VERSION="0.1.2"
 
 log() {
     echo -e "$(date '+%Y-%m-%d %H:%M:%S') - $1"


### PR DESCRIPTION
- Remove branch-based Docker tagging (type=ref,event=branch) to prevent unwanted 'main' tag
- Fix job dependencies: push-docker now depends on build-docker instead of build-jar
- Keep auto-release depending on build-jar for GitHub releases
- Update version to 0.1.2 across all components